### PR TITLE
♻️ refactoring searchable-params test to use test.each

### DIFF
--- a/src/core/shared/domain/repository/__tests__/search-params.spec.ts
+++ b/src/core/shared/domain/repository/__tests__/search-params.spec.ts
@@ -1,84 +1,81 @@
 import { SearchParams } from '../search-params';
 
 describe('SearchParams Unit Tests', () => {
-  test('page prop', () => {
+  test.each([
+    { page: null, expected: 1 },
+    { page: undefined, expected: 1 },
+    { page: '', expected: 1 },
+    { page: 'fake', expected: 1 },
+    { page: 0, expected: 1 },
+    { page: -1, expected: 1 },
+    { page: 5.5, expected: 1 },
+    { page: true, expected: 1 },
+    { page: false, expected: 1 },
+    { page: {}, expected: 1 },
+
+    { page: 1, expected: 1 },
+    { page: 2, expected: 2 },
+  ])('page prop %p', ({ page, expected }) => {
     const params = new SearchParams();
     expect(params.page).toBe(1);
 
-    const arrange = [
-      { page: null, expected: 1 },
-      { page: undefined, expected: 1 },
-      { page: '', expected: 1 },
-      { page: 'fake', expected: 1 },
-      { page: 0, expected: 1 },
-      { page: -1, expected: 1 },
-      { page: 5.5, expected: 1 },
-      { page: true, expected: 1 },
-      { page: false, expected: 1 },
-      { page: {}, expected: 1 },
-
-      { page: 1, expected: 1 },
-      { page: 2, expected: 2 },
-    ];
-
-    arrange.forEach((i) => {
-      expect(new SearchParams({ page: i.page as any }).page).toBe(i.expected);
-    });
+    expect(new SearchParams({ page: page as any }).page).toBe(expected);
   });
 
-  test('per_page prop', () => {
+  test.each([
+    { per_page: null, expected: 15 },
+    { per_page: undefined, expected: 15 },
+    { per_page: '', expected: 15 },
+    { per_page: 'fake', expected: 15 },
+    { per_page: 0, expected: 15 },
+    { per_page: -1, expected: 15 },
+    { per_page: 5.5, expected: 15 },
+    { per_page: true, expected: 15 },
+    { per_page: false, expected: 15 },
+    { per_page: {}, expected: 15 },
+
+    { per_page: 1, expected: 1 },
+    { per_page: 2, expected: 2 },
+    { per_page: 10, expected: 10 },
+  ])('per_page prop %p', (i) => {
     const params = new SearchParams();
     expect(params.per_page).toBe(15);
 
-    //TODO refactor to test.each
-    const arrange = [
-      { per_page: null, expected: 15 },
-      { per_page: undefined, expected: 15 },
-      { per_page: '', expected: 15 },
-      { per_page: 'fake', expected: 15 },
-      { per_page: 0, expected: 15 },
-      { per_page: -1, expected: 15 },
-      { per_page: 5.5, expected: 15 },
-      { per_page: true, expected: 15 },
-      { per_page: false, expected: 15 },
-      { per_page: {}, expected: 15 },
-
-      { per_page: 1, expected: 1 },
-      { per_page: 2, expected: 2 },
-      { per_page: 10, expected: 10 },
-    ];
-
-    arrange.forEach((i) => {
-      expect(new SearchParams({ per_page: i.per_page as any }).per_page).toBe(
-        i.expected,
-      );
-    });
+    expect(new SearchParams({ per_page: i.per_page as any }).per_page).toBe(
+      i.expected,
+    );
   });
 
-  test('sort prop', () => {
+  test.each([
+    { sort: null, expected: null },
+    { sort: undefined, expected: null },
+    { sort: '', expected: null },
+    { sort: 0, expected: '0' },
+    { sort: -1, expected: '-1' },
+    { sort: 5.5, expected: '5.5' },
+    { sort: true, expected: 'true' },
+    { sort: false, expected: 'false' },
+    { sort: {}, expected: '[object Object]' },
+    { sort: 'field', expected: 'field' },
+  ])('sort props %p', (i) => {
     const params = new SearchParams();
     expect(params.sort).toBeNull();
 
-    //TODO refactor to test.each
-    const arrange = [
-      { sort: null, expected: null },
-      { sort: undefined, expected: null },
-      { sort: '', expected: null },
-      { sort: 0, expected: '0' },
-      { sort: -1, expected: '-1' },
-      { sort: 5.5, expected: '5.5' },
-      { sort: true, expected: 'true' },
-      { sort: false, expected: 'false' },
-      { sort: {}, expected: '[object Object]' },
-      { sort: 'field', expected: 'field' },
-    ];
-
-    arrange.forEach((i) => {
-      expect(new SearchParams({ sort: i.sort as any }).sort).toBe(i.expected);
-    });
+    expect(new SearchParams({ sort: i.sort as any }).sort).toBe(i.expected);
   });
 
-  test('sort_dir prop', () => {
+  test.each([
+    { sort_dir: null, expected: 'asc' },
+    { sort_dir: undefined, expected: 'asc' },
+    { sort_dir: '', expected: 'asc' },
+    { sort_dir: 0, expected: 'asc' },
+    { sort_dir: 'fake', expected: 'asc' },
+
+    { sort_dir: 'asc', expected: 'asc' },
+    { sort_dir: 'ASC', expected: 'asc' },
+    { sort_dir: 'desc', expected: 'desc' },
+    { sort_dir: 'DESC', expected: 'desc' },
+  ])('sort_dir prop %p', (props) => {
     let params = new SearchParams();
     expect(params.sort_dir).toBeNull();
 
@@ -91,51 +88,30 @@ describe('SearchParams Unit Tests', () => {
     params = new SearchParams({ sort: '' });
     expect(params.sort_dir).toBeNull();
 
-    //TODO refactor to test.each
-    const arrange = [
-      { sort_dir: null, expected: 'asc' },
-      { sort_dir: undefined, expected: 'asc' },
-      { sort_dir: '', expected: 'asc' },
-      { sort_dir: 0, expected: 'asc' },
-      { sort_dir: 'fake', expected: 'asc' },
-
-      { sort_dir: 'asc', expected: 'asc' },
-      { sort_dir: 'ASC', expected: 'asc' },
-      { sort_dir: 'desc', expected: 'desc' },
-      { sort_dir: 'DESC', expected: 'desc' },
-    ];
-
-    arrange.forEach((i) => {
-      expect(
-        new SearchParams({ sort: 'field', sort_dir: i.sort_dir as any })
-          .sort_dir,
-      ).toBe(i.expected);
-    });
+    expect(
+      new SearchParams({ sort: 'field', sort_dir: props.sort_dir as any })
+        .sort_dir,
+    ).toBe(props.expected);
   });
 
-  test('filter prop', () => {
+  test.each([
+    { filter: null, expected: null },
+    { filter: undefined, expected: null },
+    { filter: '', expected: null },
+
+    { filter: 0, expected: '0' },
+    { filter: -1, expected: '-1' },
+    { filter: 5.5, expected: '5.5' },
+    { filter: true, expected: 'true' },
+    { filter: false, expected: 'false' },
+    { filter: {}, expected: '[object Object]' },
+    { filter: 'field', expected: 'field' },
+  ])('filter props %p', (props) => {
     const params = new SearchParams();
     expect(params.filter).toBeNull();
 
-    //TODO refactor to test.each
-    const arrange = [
-      { filter: null, expected: null },
-      { filter: undefined, expected: null },
-      { filter: '', expected: null },
-
-      { filter: 0, expected: '0' },
-      { filter: -1, expected: '-1' },
-      { filter: 5.5, expected: '5.5' },
-      { filter: true, expected: 'true' },
-      { filter: false, expected: 'false' },
-      { filter: {}, expected: '[object Object]' },
-      { filter: 'field', expected: 'field' },
-    ];
-
-    arrange.forEach((i) => {
-      expect(new SearchParams({ filter: i.filter as any }).filter).toBe(
-        i.expected,
-      );
-    });
+    expect(new SearchParams({ filter: props.filter as any }).filter).toBe(
+      props.expected,
+    );
   });
 });


### PR DESCRIPTION
In this pull request, the unit tests for the `SearchParams` class have been significantly refactored. The main change is the use of Jest's `test.each` function, which allows us to run the same test multiple times with different inputs. This makes the tests more concise and easier to maintain, as we can add, remove, or modify test cases simply by modifying an array of parameters.

Additionally, the test labels (the descriptions that appear when the tests are run) have been parameterized. This means that the specific values being tested are included in the test label, making it easier to understand what each test is doing and identify which test has failed if there are any failures.

Here's an example of what the new tests look like:

```typescript
test.each([
  { page: null, expected: 1 },
  { page: undefined, expected: 1 },
  { page: '', expected: 1 },
  // ... other test cases
])('page prop %p', ({ page, expected }) => {
  const params = new SearchParams();
  expect(params.page).toBe(1);
  // ... rest of the test
});
```

In this example, `%p` in the test label is replaced with the value of entry for each test case. This makes it clear what value is being tested in each run of the test.